### PR TITLE
サンプルデータのリンク修正

### DIFF
--- a/chapter1/SD_GENKOU/0.README.rst
+++ b/chapter1/SD_GENKOU/0.README.rst
@@ -11,4 +11,4 @@
 のが下記URLにありますので、よろしければそちらも
 ご一読を。
 
-http://blog.ueda.asia/?page_id=2949
+https://b.ueda.tech/?page=02949

--- a/chapter2/SD_GENKOU/0.README.rst
+++ b/chapter2/SD_GENKOU/0.README.rst
@@ -11,4 +11,4 @@
 のが下記URLにありますので、よろしければそちらも
 ご一読を。
 
-http://blog.ueda.asia/?page_id=2949
+https://b.ueda.tech/?page=02949

--- a/chapter5/README
+++ b/chapter5/README
@@ -1,7 +1,7 @@
 TESTDATAは次のリンクからダウンロードしてお使いください。
 もちろん、wget(1)で。
 
-- http://blog.ueda.asia/misc/TESTDATA.gz
+- https://file.ueda.tech/DATA_COLLECTION/TESTDATA.gz
 
 
 また、apacheのログは取り扱い注意情報が含まれているので、


### PR DESCRIPTION
サンプルデータのリンクが旧サイトのURLとなっていたので、修正しました。
blog.ueda.asia -> b.ueda.tech